### PR TITLE
Change humidity from string to number

### DIFF
--- a/AwAir_Driver.groovy
+++ b/AwAir_Driver.groovy
@@ -16,7 +16,7 @@ metadata {
         attribute "pm25", "number"
         attribute "temperature", "number"
         attribute "voc", "number"
-        attribute "humidity", "string"
+        attribute "humidity", "number"
         attribute "airQuality", "number"	
         attribute "carbonDioxide", "number" 
 


### PR DESCRIPTION
Humidity is a string, which causes a java.lang.ClassCastException when using humidity in a RuleMachine TriggerEvent. Changing to number resolves issue and the RuleMachine rule now works properly